### PR TITLE
update druid to version 0.8 and some small fixes

### DIFF
--- a/audio_ops/src/sampler.rs
+++ b/audio_ops/src/sampler.rs
@@ -25,7 +25,7 @@ impl Op for TableReader {
             let z = ix * self.sample_rate;
             let i = z as usize;
             let k = z.fract();
-            let a = f64::from_bits(self.table[(i % size)][channel].load(Ordering::Relaxed));
+            let a = f64::from_bits(self.table[i % size][channel].load(Ordering::Relaxed));
             let b = f64::from_bits(self.table[(i + 1) % size][channel].load(Ordering::Relaxed));
             *sample = (1.0 - k) * a + k * b;
         }

--- a/audio_program/src/lib.rs
+++ b/audio_program/src/lib.rs
@@ -422,7 +422,7 @@ fn rewrite_terms(stmts: &[TextOp]) -> Vec<TextOp> {
     let mut result: Vec<TextOp> = Vec::new();
     let mut new_term: Option<Term> = None;
     let mut terms: HashMap<String, Term> = Default::default();
-    let mut stack: Vec<TextOp> = Vec::from(stmts.clone());
+    let mut stack: Vec<TextOp> = Vec::from(stmts);
     stack.reverse();
     while let Some(stmt) = stack.pop() {
         // This is a known term, let's rewrite it...

--- a/audio_vm/src/stack.rs
+++ b/audio_vm/src/stack.rs
@@ -14,7 +14,7 @@ impl Stack {
     pub fn new() -> Self {
         Stack {
             data: [0.0; STACK_CAPACITY],
-            /// Index of the top of the stack (in Samples, not Frames).
+            // Index of the top of the stack (in Samples, not Frames).
             top: 0,
         }
     }

--- a/sound_garden_druid/Cargo.toml
+++ b/sound_garden_druid/Cargo.toml
@@ -8,7 +8,7 @@ description = "Sound Garden Druid"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-druid = { git = "https://github.com/linebender/druid.git", version = "0.7" }
+druid = { git = "https://github.com/linebender/druid.git", version = "0.8" }
 anyhow = "1.0.37"
 clap = "2.33.3"
 crossbeam-channel = "0.5.0"

--- a/sound_garden_druid/src/main.rs
+++ b/sound_garden_druid/src/main.rs
@@ -109,7 +109,7 @@ fn main() -> Result<()> {
         .map(|s| s.to_owned())
         .unwrap_or_else(|| format!("{}.sg", Local::now().to_rfc3339()));
     let node_repo = Arc::new(Mutex::new(NodeRepository::load(&filename)));
-    let main_window = WindowDesc::new(build_ui).title("Sound Garden");
+    let main_window = WindowDesc::new(build_ui()).title("Sound Garden");
     let main_window_id = main_window.id;
     let launcher = AppLauncher::with_window(main_window);
 
@@ -272,9 +272,9 @@ impl AppDelegate<Data> for App {
                         ctx.submit_command(druid::commands::SHOW_WINDOW.to(Target::Window(id)));
                     }
                     None => {
-                        let w = WindowDesc::new(|| {
+                        let w = WindowDesc::new((|| {
                             oscilloscope::Widget::default().lens(OscilloscopeLens {})
-                        })
+                        })())
                         .title("Oscilloscope");
                         self.oscilloscope = Some(w.id);
                         ctx.new_window(w);

--- a/sound_garden_format/Cargo.toml
+++ b/sound_garden_format/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.37"
-druid = { git = "https://github.com/linebender/druid.git", version = "0.7" }
+druid = { git = "https://github.com/linebender/druid.git", version = "0.8" }
 serde_cbor = "0.11.1"
 snap = "1.0.3"
 

--- a/sound_garden_types/Cargo.toml
+++ b/sound_garden_types/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-druid = { git = "https://github.com/linebender/druid.git", version = "0.7" }
+druid = { git = "https://github.com/linebender/druid.git", version = "0.8" }
 rand = "0.8.1"
 
 [dependencies.serde]

--- a/thread_worker/src/lib.rs
+++ b/thread_worker/src/lib.rs
@@ -26,7 +26,7 @@ impl Drop for ScopedThread {
         // escalate panic, but avoid aborting the process
         if let Err(e) = res {
             if !thread::panicking() {
-                panic!(e)
+                panic!("{:?}", e)
             }
         }
     }


### PR DESCRIPTION
update druid to version 0.8 (because with 0.7 it didn't compile, maybe because of the updated rust? idk) and just follow the compiler hints to fix errors and remove warnings